### PR TITLE
Replaced lib/environment.js with debug module

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -1,6 +1,0 @@
-module.exports = {
-  current: process.env.NODE_ENV || 'development',
-  PRODUCTION: 'production',
-  TEST: 'test',
-  DEVELOPMENT: 'development'
-}

--- a/lib/match_maker.js
+++ b/lib/match_maker.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var utils = require('./utils')
-  , env = require('./environment')
+  , debug = require('debug')('colyseus:match_maker');
 
 class MatchMaker {
 
@@ -96,7 +96,7 @@ class MatchMaker {
       this.unlockRoom(roomName, room)
 
     } catch (e) {
-      if (env.current !== env.TEST) { console.log(e.stack) }
+      debug(e.stack)
       room = null
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,7 @@ var EventEmitter = require('events').EventEmitter
   , MatchMaker = require('./match_maker')
 
   , utils = require('./utils')
-  , env = require('./environment')
+  , debug = require('debug')('colyseus:server');
 
 // // memory debugging
 // setInterval(function() { console.log(require('util').inspect(process.memoryUsage())); }, 1000)
@@ -72,7 +72,7 @@ class Server extends EventEmitter {
       try {
         this.onJoinRoomRequest(client, message[1], message[2])
       } catch (e) {
-        if (env.current !== env.TEST) { console.log(e.stack) }
+        debug(e.stack);
         client.send(msgpack.encode([protocol.JOIN_ERROR, message[1], e.message]), { binary: true })
       }
 

--- a/package.json
+++ b/package.json
@@ -16,12 +16,13 @@
   "scripts": {
     "start": "nodemon --harmony ./examples/server.js",
     "debug": "node-debug --harmony ./examples/server.js",
-    "test": "NODE_ENV=test mocha --harmony"
+    "test": "mocha --harmony"
   },
   "engines": {
     "node": ">= 5.x"
   },
   "dependencies": {
+    "debug": "^2.2.0",
     "fast-json-patch": "Starcounter-Jack/JSON-Patch",
     "msgpack-lite": "^0.1.13",
     "shortid": "^2.2.4",
@@ -35,7 +36,6 @@
     "mocha": "^2.3.4",
     "node-inspector": "^0.12.3",
     "nodemon": "^1.7.1",
-
     "immutable": "^3.7.6",
     "immutable-diff": "^0.1.1"
   }


### PR DESCRIPTION
Was browsing the code and noticed the use of `lib/environment.js` could be replaced with `debug` to make life a bit easier.

Using `debug` is identical to `console.log`, except nothing is actually logged unless you have the DEBUG environment variable set.

So to enable the `lib/server.js` debug logging, run the server with `DEBUG=colyseus:server node server.js`. To enable all colyseus debugging, use `DEBUG=colyseus:*`.