### PR TITLE
Added use strict for node v4+ support for ES6 features

### DIFF
--- a/examples/rooms/chat_room.js
+++ b/examples/rooms/chat_room.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Room = require('../../lib/room')
 
 class ChatRoom extends Room {

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var colyseus = require('../index')
   , http = require('http')
   , express = require('express')

--- a/lib/state/observer.js
+++ b/lib/state/observer.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var jsonpatch = require('fast-json-patch')
 
 class StateObserver {

--- a/test/match_maker_test.js
+++ b/test/match_maker_test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var assert = require('assert')
   , MatchMaker = require('../lib/match_maker')
   , Room = require('../lib/room')

--- a/test/room_test.js
+++ b/test/room_test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var assert = require('assert')
   , Room = require('../lib/room')
   , protocol = require('../lib/protocol')

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var assert = require('assert')
   , Server = require('../lib/server')
   , Room = require('../lib/room')

--- a/test/state_observer_test.js
+++ b/test/state_observer_test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var assert = require('assert')
   , StateObserver = require('../lib/state/observer')
   , msgpack = require('msgpack-lite')

--- a/test/utils/mock.js
+++ b/test/utils/mock.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var shortid = require('shortid')
   , EventEmitter = require('events').EventEmitter
 


### PR DESCRIPTION
Good news is all I had to do to get this to work was to add `'use strict';` to all the JS files to enable some ES6 functionality on node v4+.

`npm test` passes the tests. Running straight `mocha` without the --harmony flag also passes on v4. I tried running the example but that didn't seem to be in a working state right now.