### PR TITLE
Make version bump to support new version of uws

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "msgpack-lite": "^0.1.26",
     "shortid": "^2.2.6",
     "timeframe": "^0.3.5",
-    "uws": "^0.14.0"
+    "uws": "^0.14.1"
   },
   "devDependencies": {
     "assert": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Multiplayer Game Server for Node.js.",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",


### PR DESCRIPTION
I cannot find a workaround to install colyseus in it's current state. After a version bump, it works, the tests pass also.