### PR TITLE
Fix race condition

### DIFF
--- a/src/ClusterServer.ts
+++ b/src/ClusterServer.ts
@@ -109,7 +109,11 @@ export class ClusterServer {
 
     if (options.server) {
       // Don't expose internal server to the outside.
-      this.server = setupWorker(options.server.listen(0, "localhost"), this.matchMaker);
+      options.server.on('listening', () => {
+          this.server = setupWorker(options.server, this.matchMaker);
+      });
+
+      options.server.listen(0, 'localhost');
     }
   }
 


### PR DESCRIPTION
Sometimes a type error occour: 

```
/src/colyseus-examples/node_modules/colyseus/lib/cluster/Worker.js:71
            var request = new http.ClientRequest({ port: server.address().port });
                                                                         ^

TypeError: Cannot read property 'port' of null
```
This should fix the race condition.
