### PR TITLE
Fix tests that fails randomly

### DIFF
--- a/test/PatchTest.ts
+++ b/test/PatchTest.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as msgpack from "msgpack-lite";
 import { Room } from "../src/Room";
-import { createDummyClient, DummyRoom } from "./utils/mock";
+import { createDummyClient, DummyRoom, DummyRoomWithState } from "./utils/mock";
 import { Protocol } from "../src/Protocol";
 
 describe('Patch', function() {
@@ -12,7 +12,7 @@ describe('Patch', function() {
   })
 
   describe('patch interval', function() {
-      let room = new DummyRoom();
+      let room = new DummyRoomWithState();
       room.setPatchRate(1000 / 20);
       assert.equal("object", typeof((<any>room)._patchInterval));
       assert.equal(1000 / 20, (<any>room)._patchInterval._idleTimeout, "should have patch rate set");

--- a/test/RoomTest.ts
+++ b/test/RoomTest.ts
@@ -204,7 +204,7 @@ describe('Room', function() {
     });
 
     it("should send disconnect message to all clients", (done) => {
-      let room = new DummyRoom();
+      let room = new DummyRoomWithState();
 
       // connect 10 clients
       let client1 = createDummyClient();


### PR DESCRIPTION
They fails because:

```
Uncaught Error: trying to broadcast null state. you should call #setState on constructor o
r during user connection.
```

So, let's provide them a state.