### PR TITLE
Don't try to create a room with an invalid name

### DIFF
--- a/src/MatchMaker.ts
+++ b/src/MatchMaker.ts
@@ -59,8 +59,7 @@ export class MatchMaker {
 
     if (!this.hasHandler(roomToJoin) && isValidId(roomToJoin)) {
       room = this.joinById(roomToJoin, clientOptions);
-
-    } else {
+    } else if (isValidId(roomToJoin)) {
       room = this.requestToJoinRoom( roomToJoin, clientOptions ).room
         || (allowCreateRoom && this.create( roomToJoin, clientOptions ));
     }

--- a/test/MatchMakerTest.ts
+++ b/test/MatchMakerTest.ts
@@ -9,20 +9,20 @@ describe('MatchMaker', function() {
 
   before(function() {
     matchMaker = new MatchMaker()
-    matchMaker.addHandler('room', DummyRoom);
+    matchMaker.addHandler('test_room', DummyRoom);
     matchMaker.addHandler('dummy_room', DummyRoom);
   });
 
   describe('room handlers', function() {
 
     it('should add handler with name', function() {
-      assert.equal(DummyRoom, matchMaker.handlers.room[0]);
-      assert.equal(0, Object.keys(matchMaker.handlers.room[1]).length);
-      assert.equal(false, matchMaker.hasAvailableRoom('room'));
+      assert.equal(DummyRoom, matchMaker.handlers.test_room[0]);
+      assert.equal(0, Object.keys(matchMaker.handlers.test_room[1]).length);
+      assert.equal(false, matchMaker.hasAvailableRoom('test_room'));
     });
 
     it('should create a new room on joinOrCreateByName', function(done) {
-      matchMaker.onJoinRoomRequest('room', {}, true, (err, room) => {
+      matchMaker.onJoinRoomRequest('test_room', {}, true, (err, room) => {
         assert.ok(typeof(room.roomId) === "string");
         assert.ok(room instanceof Room);
         done();
@@ -42,7 +42,7 @@ describe('MatchMaker', function() {
     });
 
     it('shouldn\t return room instance when trying to join existing room by id with invalid params', function(done) {
-      matchMaker.onJoinRoomRequest('room', {}, true, (err, room) => {
+      matchMaker.onJoinRoomRequest('test_room', {}, true, (err, room) => {
         assert.ok(room instanceof Room);
         assert.equal(matchMaker.joinById(room.roomId, { invalid_param: 1 }), undefined);
         done();


### PR DESCRIPTION
When an user try to join a room with an invalid name the server crash with this error:

```
/src/game/node_modules/colyseus/lib/MatchMaker.js:153
        var room = null, handler = this.handlers[roomName][0], options = this.handlers[roomName][1];
                                                          ^

TypeError: Cannot read property '0' of undefined
    at MatchMaker.create (/src/game/node_modules/colyseus/lib/MatchMaker.js:153:59)
    at MatchMaker.onJoinRoomRequest (/src/game/node_modules/colyseus/lib/MatchMaker.js:62:45)
    at process.<anonymous> (/src/game/node_modules/colyseus/lib/cluster/Worker.js:104:24)
    at emitTwo (events.js:130:20)
    at process.emit (events.js:213:7)
    at handleMessage (internal/child_process.js:753:14)
    at Pipe.channel.onread (internal/child_process.js:472:11)
worker 6586 died. Respawn.
```

This should fix that.
