### PR TITLE
Dont try to create a room with invalid handler

### DIFF
--- a/src/MatchMaker.ts
+++ b/src/MatchMaker.ts
@@ -57,9 +57,10 @@ export class MatchMaker {
 
     clientOptions.sessionId = generateId();
 
-    if (!this.hasHandler(roomToJoin) && isValidId(roomToJoin)) {
-      room = this.joinById(roomToJoin, clientOptions);
-
+    if (!this.hasHandler(roomToJoin)) {
+      if (isValidId(roomToJoin)) {
+        room = this.joinById(roomToJoin, clientOptions);
+      }
     } else {
       room = this.requestToJoinRoom( roomToJoin, clientOptions ).room
         || (allowCreateRoom && this.create( roomToJoin, clientOptions ));

--- a/test/MatchMakerTest.ts
+++ b/test/MatchMakerTest.ts
@@ -71,5 +71,13 @@ describe('MatchMaker', function() {
       done();
     });
 
+    it('should emit error if room name is not a valid id', function(done) {
+      const invalidRoomName = '';
+      matchMaker.onJoinRoomRequest(invalidRoomName, {}, true, (err, room) => {
+        assert.equal('join_request_fail', err);
+        done();
+      });
+    });
+
   });
 });

--- a/test/MatchMakerTest.ts
+++ b/test/MatchMakerTest.ts
@@ -7,7 +7,7 @@ import { createDummyClient, DummyRoom } from "./utils/mock";
 describe('MatchMaker', function() {
   let matchMaker;
 
-  before(function() {
+  beforeEach(function() {
     matchMaker = new MatchMaker()
     matchMaker.addHandler('room', DummyRoom);
     matchMaker.addHandler('dummy_room', DummyRoom);
@@ -62,11 +62,12 @@ describe('MatchMaker', function() {
     });
 
     it('should call "onDispose" when room is not created', function(done) {
-      sinon.stub(DummyRoom.prototype, 'requestJoin').returns(false);
+      const stub = sinon.stub(DummyRoom.prototype, 'requestJoin').returns(false);
       const spy = sinon.spy(DummyRoom.prototype, 'onDispose');
       const room = matchMaker.create('dummy_room', {});
       assert.ok(spy.calledOnce);
       assert.equal(null, room);
+      stub.restore();
       done();
     });
 

--- a/test/RoomTest.ts
+++ b/test/RoomTest.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import * as msgpack from "msgpack-lite";
+import * as sinon from 'sinon';
 import { Room } from "../src/Room";
 import { Protocol } from "../src/Protocol";
 import {
@@ -204,7 +205,9 @@ describe('Room', function() {
     });
 
     it("should send disconnect message to all clients", (done) => {
-      let room = new DummyRoomWithState();
+      let room = new DummyRoom();
+
+      let clock = sinon.useFakeTimers();
 
       // connect 10 clients
       let client1 = createDummyClient();
@@ -225,7 +228,8 @@ describe('Room', function() {
       setTimeout(() => (<any>room)._onLeave(client3, true), 0);
 
       // fulfil the test
-      setTimeout(done, 5);
+      clock.runAll();
+      done();
     });
 
   });


### PR DESCRIPTION
This PR include:

- Correct patch for #84 + test.
- A test still fails randomly even after #83, this should finally fix that.
- Missing `stub.restore()` of a test introduced in #79.