### PR TITLE
Remove express dependency

### DIFF
--- a/src/cluster/Worker.ts
+++ b/src/cluster/Worker.ts
@@ -99,6 +99,7 @@ export function setupWorker (server: net.Server, matchMaker: MatchMaker) {
       // '_flush' method has been lost after redirecting the socket
       //
       request._flush = function() {};
+      request._dump = function() {};
 
       // emit request to server
       socket.parser.onIncoming(request);

--- a/src/matchmaking/Process.ts
+++ b/src/matchmaking/Process.ts
@@ -1,4 +1,4 @@
-import * as express from "express";
+import { createServer } from 'http';
 import * as msgpack from "msgpack-lite";
 import * as memshared from "memshared";
 import { Server as WebSocketServer } from "uws";
@@ -9,8 +9,8 @@ import { handleUpgrade, setUserId } from "../cluster/Worker";
 
 import { debugMatchMaking } from "../Debug";
 
-const app = new express();
-const server = app.listen(0, "localhost");
+const server = createServer();
+server.listen(0, "localhost");
 
 let wss = new WebSocketServer({
   server: server,


### PR DESCRIPTION
Right now your application require to use `express`. We could move `express` from the `package.json`'s `devDependencies` to the `dependencies`, or remove it entirely. This PR does the latter, allowing the user to do this:

```
import { createServer } from 'http';

const httpServer = createServer((req, res) => {
  // ...
});

const gameServer = new Server({ server: httpServer });
```