### PR TITLE
allow to listen to 'join'/'leave'/'create'/'dispose' events from outside

### DIFF
--- a/src/ClusterServer.ts
+++ b/src/ClusterServer.ts
@@ -9,7 +9,7 @@ import * as parseURL from "url-parse";
 import { spawnWorkers, spawnMatchMaking, getNextWorkerForSocket } from "./cluster/Master";
 import { setupWorker } from "./cluster/Worker";
 import { Protocol } from "./Protocol";
-import { MatchMaker } from "./MatchMaker";
+import { MatchMaker, RegisteredHandler } from "./MatchMaker";
 import { generateId } from "./";
 import { debugCluster } from "./Debug";
 
@@ -92,15 +92,18 @@ export class ClusterServer {
     }
   }
 
-  register (name: string, handler: Function, options: any = {}) {
-    if (!cluster.isMaster) {
-      this.matchMaker.addHandler(name, handler, options);
+  register (name: string, handler: Function, options: any = {}): RegisteredHandler {
+    if (!cluster.isWorker) {
+      console.warn("ClusterServer#register should be called from a worker process.");
+      return;
     }
+
+    return this.matchMaker.registerHandler(name, handler, options);
   }
 
   attach (options: { server: http.Server }) {
     if (!cluster.isWorker) {
-      // ClusterServer#attach method should only be called from a worker process.
+      console.warn("ClusterServer#attach should be called from a worker process.");
       return;
     }
 

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -5,7 +5,7 @@ import * as msgpack from "msgpack-lite";
 import * as parseURL from "url-parse";
 
 import { Server as WebSocketServer, IServerOptions } from "uws";
-import { MatchMaker } from "./MatchMaker";
+import { MatchMaker, RegisteredHandler } from "./MatchMaker";
 import { Protocol, send, decode } from "./Protocol";
 import { Client } from "./index";
 import { handleUpgrade, setUserId } from "./cluster/Worker";
@@ -43,8 +43,8 @@ export class Server {
     this.httpServer.listen(port, hostname, backlog, listeningListener);
   }
 
-  register (name: string, handler: Function, options: any = {}) {
-    this.matchMaker.addHandler(name, handler, options);
+  register (name: string, handler: Function, options: any = {}): RegisteredHandler {
+    return this.matchMaker.registerHandler(name, handler, options);
   }
 
   onConnection = (client: Client) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { Server } from "./Server";
 export { ClusterServer } from "./ClusterServer";
 export { Room } from "./Room";
 export { Protocol } from "./Protocol";
+export { RegisteredHandler } from "./MatchMaker";
 
 // State Helper Types
 export type EntityMap<T> = {[ entityId:string ]: T};

--- a/test/utils/mock.ts
+++ b/test/utils/mock.ts
@@ -44,7 +44,7 @@ export class DummyRoom extends Room {
     return !options.invalid_param
   }
 
-  onInit () {}
+  onInit () { this.setState({}); }
   onDispose() {}
   onJoin() {}
   onLeave() {}
@@ -52,7 +52,7 @@ export class DummyRoom extends Room {
 }
 
 export class RoomWithError extends Room {
-  onInit () {}
+  onInit () { this.setState({}); }
   onDispose() {}
   onJoin() {
     (<any>this).iHaveAnError();
@@ -90,7 +90,7 @@ export class DummyRoomWithTimeline extends Room {
     return !options.invalid_param
   }
 
-  onInit () {}
+  onInit () { this.setState({}); }
   onDispose() {}
   onJoin() {}
   onLeave() {}

--- a/usage/ClusteredServer.ts
+++ b/usage/ClusteredServer.ts
@@ -9,9 +9,6 @@ const PORT = 8080;
 
 let gameServer = new ClusterServer();
 
-// Register ChatRoom as "chat"
-gameServer.register("chat", ChatRoom);
-
 if (cluster.isMaster) {
   gameServer.listen(PORT);
   gameServer.fork();
@@ -23,6 +20,14 @@ if (cluster.isMaster) {
     console.log("something!", process.pid);
     res.send("Hey!");
   });
+
+  // Register ChatRoom as "chat"
+  gameServer.register("chat", ChatRoom).
+    // demonstrating public events.
+    on("create", (room) => console.log("room created!", room.roomId)).
+    on("join", (room, client) => console.log("client", client.id, "joined", room.roomId)).
+    on("leave", (room, client) => console.log("client", client.id, "left", room.roomId)).
+    on("dispose", (room) => console.log("room disposed!", room.roomId));
 
   // Create HTTP Server
   gameServer.attach({ server: app });

--- a/usage/Server.ts
+++ b/usage/Server.ts
@@ -14,7 +14,12 @@ const server = http.createServer(app);
 const gameServer = new Server({ server: server });
 
 // Register ChatRoom as "chat"
-gameServer.register("chat", ChatRoom);
+gameServer.register("chat", ChatRoom).
+  // demonstrating public events.
+  on("create", (room) => console.log("room created!", room.roomId)).
+  on("join", (room, client) => console.log("client", client.id, "joined", room.roomId)).
+  on("leave", (room, client) => console.log("client", client.id, "left", room.roomId)).
+  on("dispose", (room) => console.log("room disposed!", room.roomId));
 
 app.use(express.static(__dirname));
 


### PR DESCRIPTION
I'll leave this pull-request open for a while for discussion before merging. This is a suggestion from @derwish-pro.

The `register` method now returns an `EventEmitter` instance, which allows you to listen to `"create"`, `"dispose"`, `"join"` and `"leave"` events from outside the room scope.

**Example**

```
gameServer.register("chat", ChatRoom).
    on("create", (room) => console.log("room created!", room.roomId)).
    on("join", (room, client) => console.log("client", client.id, "joined", room.roomId)).
    on("leave", (room, client) => console.log("client", client.id, "left", room.roomId)).
    on("dispose", (room) => console.log("room disposed!", room.roomId));
```

Feedback is very welcome! Cheers!