### PR TITLE
improve graceful shutdown feature. add onShutdown() method. #120

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     "ws": "^3.3.3"
   },
   "devDependencies": {
-    "@types/uws": "^0.13.1",
-    "@types/ip": "^0.0.29",
     "@types/debug": "^0.0.30",
-    "@types/node": "^7.0.18",
     "@types/fossil-delta": "^1.0.0",
+    "@types/ip": "^0.0.29",
     "@types/mocha": "^2.2.32",
+    "@types/node": "^7.0.18",
     "@types/sinon": "^4.0.0",
+    "@types/uws": "^0.13.1",
     "assert": "^1.3.0",
     "benchmark": "^2.1.1",
     "express": "^4.16.2",

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,3 +1,35 @@
+//
+// nodemon sends SIGUSR2 before reloading
+// (https://github.com/remy/nodemon#controlling-shutdown-of-your-script)
+//
+export function registerGracefulShutdown (callback) {
+  let calledOnce = false;
+  ['SIGINT', 'SIGTERM', 'SIGUSR2'].forEach(signal => {
+    process.once(signal, () => callback(signal));
+  });
+}
+
+export class Deferred {
+  promise: Promise<any>;
+
+  reject: Function;
+  resolve: Function;
+
+  constructor() {
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+
+  then (func: (value: any) => any) {
+    return this.promise.then(func);
+  }
+
+  catch (func: (value: any) => any) {
+    return this.promise.catch(func);
+  }
+}
 
 export function spliceOne (arr: Array<any>, index: number): boolean {
   // manually splice availableRooms array

--- a/src/cluster/Master.ts
+++ b/src/cluster/Master.ts
@@ -5,12 +5,16 @@ import * as net from "net";
 import * as ip from "ip";
 
 import { Protocol } from "../Protocol";
-import { spliceOne } from "../Utils";
+import { spliceOne, registerGracefulShutdown, Deferred } from "../Utils";
 import { debugCluster } from "../Debug";
 import { Worker } from "cluster";
 
 const seed = (Math.random() * 0xffffffff) | 0;
-let workers = [];
+const workers: Worker[] = [];
+
+// keep number of workers gracefully shut down
+let workersShutDown = 0;
+export const onWorkersShutdown = new Deferred();
 
 export function getNextWorkerForSocket (socket: net.Socket) {
   let hash = getHash(ip.toBuffer(socket.remoteAddress || '127.0.0.1'));
@@ -57,17 +61,26 @@ function spawnWorker () {
   enableProcessCommunication(worker);
 
   // auto-spawn a new worker on failure
-  worker.on("exit", () => {
-    console.warn("worker", process.pid, "died. Respawn.")
+  worker.on("exit", function (code, signal) {
+    if (signal !== "SIGINT" && signal !== "SIGTERM" && signal !== "SIGUSR2") {
+      console.warn("worker", process.pid, "died. Respawn.")
 
-    // remove workerId from shared store
-    spliceOne(memshared.store['workerIds'], memshared.store['workerIds'].indexOf(process.pid));
+      // remove workerId from shared store
+      spliceOne(memshared.store['workerIds'], memshared.store['workerIds'].indexOf(process.pid));
 
-    // remove worker from workers list.
-    spliceOne(workers, workers.indexOf(worker));
+      // remove worker from workers list.
+      spliceOne(workers, workers.indexOf(worker));
 
-    // spawn new worker as a replacement for this one
-    spawnWorker();
+      // spawn new worker as a replacement for this one
+      spawnWorker();
+
+    } else {
+      workersShutDown++;
+
+      if (workersShutDown === workers.length) {
+        onWorkersShutdown.resolve();
+      }
+    }
   });
 
   return worker;
@@ -80,7 +93,6 @@ function enableProcessCommunication(worker: child_process.ChildProcess | cluster
       workerProcess.send(message);
     }
   });
-
 }
 
 /**

--- a/src/matchmaking/Process.ts
+++ b/src/matchmaking/Process.ts
@@ -44,6 +44,10 @@ function onConnect (client: Client, req?: http.IncomingMessage) {
     client.upgradeReq = req;
   }
 
+  // since ws@3.3.3 it's required to listen to 'error' to prevent server crash
+  // https://github.com/websockets/ws/issues/1256
+  client.on('error', (e) => {/*console.error("[ERROR]", e);*/ });
+
   setUserId(client);
 
   client.on('message', (message) => {
@@ -87,8 +91,6 @@ function onConnect (client: Client, req?: http.IncomingMessage) {
     });
 
   });
-
-  client.on('error', (e) => {/*console.error("[ERROR]", e);*/});
 }
 
 function broadcastJoinRoomRequest (availableWorkerIds: string[], client: Client, roomName: string, joinOptions: any) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
         "sourceMap": false
     },
     "include": [
-      "src/**/*.ts",
-      "usage/**/*.ts",
+      "src/**/*.ts"
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
         "sourceMap": false
     },
     "include": [
-      "src/**/*.ts"
+      "src/**/*.ts",
+      "usage/**/*.ts",
     ]
 }

--- a/usage/ChatRoom.ts
+++ b/usage/ChatRoom.ts
@@ -7,7 +7,10 @@ export class ChatRoom extends Room<any> {
   }
 
   onJoin (client, options) {
-    console.log("client has joined!", client, options);
+    console.log("client has joined!");
+    console.log("client.id:", client.id);
+    console.log("client.sessionId:", client.sessionId);
+    console.log("with options", options);
     this.state.messages.push(`${ client.id } joined.`);
   }
 
@@ -26,7 +29,15 @@ export class ChatRoom extends Room<any> {
   }
 
   onDispose () {
-    console.log("Dispose ChatRoom");
+    console.log("Disposing ChatRoom...");
+
+    // perform async tasks to disconnect all players
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        console.log("async task finished, let's dispose the room now!")
+        reject();
+      }, 2000);
+    });
   }
 
 }

--- a/usage/ClusteredServer.ts
+++ b/usage/ClusteredServer.ts
@@ -13,8 +13,20 @@ if (cluster.isMaster) {
   gameServer.listen(PORT);
   gameServer.fork();
 
+  gameServer.onShutdown(() => {
+    console.log("CUSTOM SHUTDOWN ROUTINE MASTER: STARTED");
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        console.log("CUSTOM SHUTDOWN ROUTINE MASTER: FINISHED");
+        resolve();
+      }, 1000);
+    })
+  });
+
 } else {
   const app = new express();
+
+  app.on("close", () => console.log("express close!"));
 
   app.get("/something", (req, res) => {
     console.log("something!", process.pid);
@@ -28,6 +40,16 @@ if (cluster.isMaster) {
     on("join", (room, client) => console.log("client", client.id, "joined", room.roomId)).
     on("leave", (room, client) => console.log("client", client.id, "left", room.roomId)).
     on("dispose", (room) => console.log("room disposed!", room.roomId));
+
+  gameServer.onShutdown(() => {
+    console.log("CUSTOM SHUTDOWN WORKER: STARTED");
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        console.log("CUSTOM SHUTDOWN WORKER: FINISHED");
+        resolve();
+      }, 1000);
+    })
+  });
 
   // Create HTTP Server
   gameServer.attach({ server: app });

--- a/usage/Server.ts
+++ b/usage/Server.ts
@@ -28,6 +28,16 @@ app.get("/something", (req, res) => {
   res.send("Hey!");
 });
 
+gameServer.onShutdown(() => {
+  console.log("CUSTOM SHUTDOWN ROUTINE: STARTED");
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      console.log("CUSTOM SHUTDOWN ROUTINE: FINISHED");
+      resolve();
+    }, 1000);
+  })
+});
+
 gameServer.listen(port);
 
 console.log(`Listening on http://${ endpoint }:${ port }`)


### PR DESCRIPTION
(Solves #120)

This pull request adds `onShutdown()` method on `Server` and `ClusterServer`.

The new graceful shutdown order is:
- Match-making may dispose all rooms asynchronously
- Registered `onShutdown` sync/async method is called
- Process is killed

Usage example:

#### Using `ClusterServer`

```typescript
if (cluster.isMaster) {
  gameServer.fork();

  // shutting down master node
  gameServer.onShutdown(() => {
    return new Promise((resolve, reject) => {
      setTimeout(() => {
        console.log("CUSTOM SHUTDOWN MASTER: FINISHED");
        resolve();
      }, 1000);
    })
  });

} else {
  // shutting down each worker (optional)
  gameServer.onShutdown(() => {
    return new Promise((resolve, reject) => {
      setTimeout(() => {
        console.log("CUSTOM SHUTDOWN WORKER: FINISHED");
        resolve();
      }, 1000);
    })
  });
}
```

#### Using `Server`

```typescript
gameServer.onShutdown(() => {
  return new Promise((resolve, reject) => {
    setTimeout(() => {
      console.log("CUSTOM SHUTDOWN: FINISHED");
      resolve();
    }, 1000);
  })
});
```

Any feedback is welcome! @oyed