### PR TITLE
ClusterServer + body-parser - fix forwarding http requests with special characters its body.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colyseus",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Multiplayer Game Server for Node.js.",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
@@ -53,6 +53,7 @@
     "all-contributors-cli": "^4.10.1",
     "assert": "^1.3.0",
     "benchmark": "^2.1.1",
+    "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "mocha": "2.3.2",
     "nodemon": "^1.14.8",

--- a/usage/ClusteredServer.ts
+++ b/usage/ClusteredServer.ts
@@ -1,6 +1,7 @@
 import * as cluster from "cluster";
 import * as path from 'path';
 import * as express from 'express';
+import * as bodyParser from "body-parser";
 
 import { ClusterServer } from "../src/ClusterServer";
 import { ChatRoom } from "./ChatRoom";
@@ -26,11 +27,19 @@ if (cluster.isMaster) {
 } else {
   const app = new express();
 
+  app.use(bodyParser.json());
+
   app.on("close", () => console.log("express close!"));
 
   app.get("/something", (req, res) => {
     console.log("something!", process.pid);
+    console.log("GET /something")
     res.send("Hey!");
+  });
+
+  app.post("/something", (req, res) => {
+    console.log("POST /something")
+    res.json(req.body);
   });
 
   // Register ChatRoom as "chat"

--- a/usage/Server.ts
+++ b/usage/Server.ts
@@ -1,5 +1,6 @@
 import * as http from "http";
 import * as express from "express";
+import * as bodyParser from "body-parser";
 
 import { Server } from "../src/Server";
 import { ChatRoom } from "./ChatRoom";
@@ -8,6 +9,7 @@ const port = 8080;
 const endpoint = "localhost";
 
 const app = express();
+app.use(bodyParser.json());
 
 // Create HTTP & WebSocket servers
 const server = http.createServer(app);
@@ -23,9 +25,16 @@ gameServer.register("chat", ChatRoom).
 
 app.use(express.static(__dirname));
 
+
 app.get("/something", (req, res) => {
   console.log("something!", process.pid);
+  console.log("GET /something")
   res.send("Hey!");
+});
+
+app.post("/something", (req, res) => {
+  console.log("POST /something")
+  res.json(req.body);
 });
 
 gameServer.onShutdown(() => {


### PR DESCRIPTION
When sending special UTF8 characters on regular HTTP requests, the server was throwing this error:

```
Error: request size did not match content length
    at IncomingMessage.onEnd (/root/crashracing-production/build/node_modules/raw-body/index.js:298:12)
    at emitNone (events.js:86:13)
    at IncomingMessage.emit (events.js:185:7)
    at process.<anonymous> (/root/crashracing-production/build/node_modules/colyseus/lib/cluster/Worker.js:71:21)
    at emitTwo (events.js:111:20)
    at process.emit (events.js:191:7)
    at processEmit [as emit] (/root/crashracing-production/build/node_modules/signal-exit/index.js:155:32)
    at process.nextTick (internal/child_process.js:744:12)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```

**How to reproduce:**

- Start `ClusterServer`, accepting http requests from the worker.
- Make an http request sending special UTF8 characters.
- Wait a couple of seconds and the error will be thrown

```
 curl -XPOST 'http://localhost:8080/something' -H "Content-Type: application/json"  -d '{"name":"áéíóú"}'
```

This pull-request fixes this problem by re-evaluating the `"content-length"` when forwarding the http request to one of its workers.