### PR TITLE
Allow client reconnection

### DIFF
--- a/src/MatchMaker.ts
+++ b/src/MatchMaker.ts
@@ -98,6 +98,7 @@ export class MatchMaker {
   public async onJoinRoomRequest(client: Client, roomToJoin: string, clientOptions: ClientOptions): Promise<string> {
     const hasHandler = this.hasHandler(roomToJoin);
     let roomId: string;
+    let isReconnect = false;
 
     if (!hasHandler && isValidId(roomToJoin)) {
       roomId = roomToJoin;
@@ -109,12 +110,10 @@ export class MatchMaker {
 
     if (clientOptions.sessionId) {
       roomId = await this.presence.get(clientOptions.sessionId);
-
-      // TODO: no need for `requestJoin` here, just reconnect the user into the room.
-      //
+      isReconnect = true;
     }
 
-    if (!roomId) {
+    if (!roomId || !clientOptions.sessionId) {
       clientOptions.sessionId = generateId();
 
       // check if there's an existing room with provided name available to join
@@ -127,7 +126,7 @@ export class MatchMaker {
     }
 
     if (isValidId(roomId)) {
-      roomId = await this.joinById(roomId, clientOptions);
+      roomId = await this.joinById(roomId, clientOptions, isReconnect);
     }
 
     // if couldn't join a room by its id, let's try to create a new one
@@ -204,12 +203,15 @@ export class MatchMaker {
     return this.handlers[ name ] !== undefined;
   }
 
-  public async joinById(roomId: string, clientOptions: ClientOptions): Promise<string> {
+  public async joinById(roomId: string, clientOptions: ClientOptions, isReconnect: boolean): Promise<string> {
     const exists = await this.presence.exists(this.getRoomChannel(roomId));
 
     if (!exists) {
       debugMatchMaking(`trying to join non-existant room "${ roomId }"`);
       return;
+
+    } else if (isReconnect && await this.remoteRoomCall(roomId, 'hasReservedSeat', [clientOptions.sessionId])) {
+      return roomId;
 
     } else if (await this.remoteRoomCall(roomId, 'hasReachedMaxClients')) {
       debugMatchMaking(`room "${ roomId }" reached maxClients.`);

--- a/src/MatchMaker.ts
+++ b/src/MatchMaker.ts
@@ -138,7 +138,7 @@ export class MatchMaker {
       // reserve seat for client on selected room
       this.remoteRoomCall(roomId, '_reserveSeat', [{
         id: client.id,
-        sessionId: clientOptions.sessionId
+        sessionId: clientOptions.sessionId,
       }]);
 
     } else {

--- a/src/MatchMaker.ts
+++ b/src/MatchMaker.ts
@@ -98,7 +98,7 @@ export class MatchMaker {
   public async onJoinRoomRequest(client: Client, roomToJoin: string, clientOptions: ClientOptions): Promise<string> {
     const hasHandler = this.hasHandler(roomToJoin);
     let roomId: string;
-    let isReconnect = false;
+    let isReconnect: boolean;
 
     if (!hasHandler && isValidId(roomToJoin)) {
       roomId = roomToJoin;
@@ -115,6 +115,7 @@ export class MatchMaker {
 
     if (!roomId || !clientOptions.sessionId) {
       clientOptions.sessionId = generateId();
+      isReconnect = false;
 
       // check if there's an existing room with provided name available to join
       if (hasHandler) {

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -113,7 +113,7 @@ export abstract class Room<T= any> extends EventEmitter {
     return (this.clients.length + this.reservedSeats.size) >= this.maxClients;
   }
 
-  public hasReservedSeat (sessionId: string): boolean {
+  public hasReservedSeat(sessionId: string): boolean {
     return this.reservedSeats.has(sessionId);
   }
 

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -403,7 +403,7 @@ export abstract class Room<T= any> extends EventEmitter {
     }
 
     // confirm room id that matches the room name requested to join
-    send(client, [ Protocol.JOIN_ROOM, client.sessionId ]);
+    send(client, [ Protocol.JOIN_ROOM, client.sessionId, this.allowReconnection ]);
 
     // emit 'join' to room handler
     this.emit('join', client);

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -113,6 +113,10 @@ export abstract class Room<T= any> extends EventEmitter {
     return (this.clients.length + this.reservedSeats.size) >= this.maxClients;
   }
 
+  public hasReservedSeat (sessionId: string): boolean {
+    return this.reservedSeats.has(sessionId);
+  }
+
   public setSimulationInterval( callback: SimulationCallback, delay: number = DEFAULT_SIMULATION_INTERVAL ): void {
     // clear previous interval in case called setSimulationInterval more than once
     if ( this._simulationInterval ) { clearInterval( this._simulationInterval ); }

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -296,8 +296,6 @@ export abstract class Room<T= any> extends EventEmitter {
     this.presence.setex(`${this.roomId}:${client.id}`, client.sessionId, reconnectionTimeout);
     this.reservedSeats.add(client.sessionId);
 
-    // TODO: add timeout in case reserved seat is never fulfilled.
-
     if (allowReconnection) {
       // store reference of the roomId this client is allowed to reconnect to.
       this.presence.setex(client.sessionId, this.roomId, reconnectionTimeout);

--- a/src/presence/MemsharedPresence.ts
+++ b/src/presence/MemsharedPresence.ts
@@ -35,6 +35,19 @@ export class MemsharedPresence implements Presence {
         });
     }
 
+    public setex(key: string, value: string, seconds: number) {
+        memshared.setex(key, seconds, value);
+    }
+
+    public async get(key: string) {
+        return new Promise((resolve, reject) => {
+            memshared.get(key, (err, data) => {
+                if (err) { return reject(err); }
+                resolve(data);
+            });
+        });
+    }
+
     public del(roomId: string) {
         memshared.del(roomId);
     }
@@ -54,6 +67,15 @@ export class MemsharedPresence implements Presence {
 
     public srem(key: string, value: any) {
         memshared.srem(key, value);
+    }
+
+    public scard(key: string) {
+        return new Promise((resolve, reject) => {
+            memshared.scard(key, (err, data) => {
+                if (err) { return reject(err); }
+                resolve(data);
+            });
+        });
     }
 
     public hset(roomId: string, key: string, value: string) {

--- a/src/presence/Presence.ts
+++ b/src/presence/Presence.ts
@@ -5,10 +5,14 @@ export interface Presence {
 
     exists(roomId: string): Promise<boolean>;
 
+    setex(key: string, value: string, seconds: number);
+    get(key: string);
+
     del(key: string): void;
     sadd(key: string, value: any);
     smembers(key: string);
     srem(key: string, value: any);
+    scard(key: string);
 
     hset(roomId: string, key: string, value: string);
     hget(roomId: string, key: string): Promise<string>;

--- a/src/presence/RedisPresence.ts
+++ b/src/presence/RedisPresence.ts
@@ -61,6 +61,19 @@ export class RedisPresence implements Presence {
         return (await this.pubsubAsync('channels', roomId)).length > 0;
     }
 
+    public setex(key: string, value: string, seconds: number) {
+        this.pub.setex(key, seconds, value);
+    }
+
+    public async get(key: string) {
+        return new Promise((resolve, reject) => {
+            this.pub.get(key, (err, data) => {
+                if (err) { return reject(err); }
+                resolve(data);
+            });
+        });
+    }
+
     public del(roomId: string) {
         this.pub.del(roomId);
     }
@@ -75,6 +88,15 @@ export class RedisPresence implements Presence {
 
     public srem(key: string, value: any) {
         this.pub.srem(key, value);
+    }
+
+    public scard(key: string) {
+        return new Promise((resolve, reject) => {
+            this.pub.scard(key, (err, data) => {
+                if (err) { return reject(err); }
+                resolve(data);
+            });
+        });
     }
 
     public hset(roomId: string, key: string, value: string) {

--- a/test/MatchMakerTest.ts
+++ b/test/MatchMakerTest.ts
@@ -5,7 +5,7 @@ import * as sinon from 'sinon';
 
 import { MatchMaker } from "../src/MatchMaker";
 import { RegisteredHandler } from './../src/matchmaker/RegisteredHandler';
-import { Room } from "../src/Room";
+import { Room, DEFAULT_SEAT_RESERVATION_TIME } from "../src/Room";
 
 import { generateId, Protocol, isValidId } from "../src";
 import { createDummyClient, DummyRoom, RoomVerifyClient, Client, RoomVerifyClientWithLock } from "./utils/mock";
@@ -336,7 +336,7 @@ describe('MatchMaker', function() {
       assert.equal(dummyRoom.clients, 0);
       assert(dummyRoom instanceof Room);
 
-      clock.tick(dummyRoom.reconnectionTimeout);
+      clock.tick(DEFAULT_SEAT_RESERVATION_TIME * 1000);
       assert(matchMaker.getRoomById(roomId) === undefined);
 
       clock.restore();
@@ -347,13 +347,13 @@ describe('MatchMaker', function() {
 
       const roomId = await matchMaker.onJoinRoomRequest(createDummyClient(), 'room', {});
       const room = matchMaker.getRoomById(roomId);
-      clock.tick(room.reconnectionTimeout - 1);
+      clock.tick(DEFAULT_SEAT_RESERVATION_TIME * 1000 - 1);
       assert(room instanceof Room);
 
       await matchMaker.onJoinRoomRequest(createDummyClient(), 'room', {});
       assert(matchMaker.getRoomById(roomId) instanceof Room);
 
-      clock.tick(room.reconnectionTimeout);
+      clock.tick(DEFAULT_SEAT_RESERVATION_TIME * 1000);
       assert(matchMaker.getRoomById(roomId) === undefined);
 
       clock.restore();
@@ -366,11 +366,11 @@ describe('MatchMaker', function() {
       const roomId = await matchMaker.onJoinRoomRequest(client, 'room', {});
       const room = matchMaker.getRoomById(roomId);
 
-      clock.tick(room.reconnectionTimeout - 1);
+      clock.tick(DEFAULT_SEAT_RESERVATION_TIME * 1000 - 1);
       assert(room instanceof Room);
 
       await matchMaker.connectToRoom(client, roomId);
-      clock.tick(room.reconnectionTimeout);
+      clock.tick(DEFAULT_SEAT_RESERVATION_TIME * 1000);
       assert(matchMaker.getRoomById(roomId) instanceof Room);
 
       clock.restore();

--- a/test/PatchTest.ts
+++ b/test/PatchTest.ts
@@ -3,12 +3,14 @@ import * as msgpack from "notepack.io";
 import { Room } from "../src/Room";
 import { createDummyClient, DummyRoom, DummyRoomWithState } from "./utils/mock";
 import { Protocol } from "../src/Protocol";
+import { LocalPresence } from './../src/presence/LocalPresence';
 
 describe('Patch', function() {
   let room: Room<any>;
 
   beforeEach(function() {
     room = new DummyRoom();
+    room.presence = new LocalPresence();
   })
 
   describe('patch interval', function() {

--- a/test/RoomTest.ts
+++ b/test/RoomTest.ts
@@ -60,8 +60,6 @@ describe('Room', function() {
       var room = new DummyRoom();
       var client = createDummyClient();
 
-      room.allowReconnection = false;
-
       (<any>room)._onJoin(client);
       assert.ok((<any>room)._patchInterval._idleTimeout > 0);
 

--- a/test/RoomTest.ts
+++ b/test/RoomTest.ts
@@ -60,6 +60,8 @@ describe('Room', function() {
       var room = new DummyRoom();
       var client = createDummyClient();
 
+      room.allowReconnection = false;
+
       (<any>room)._onJoin(client);
       assert.ok((<any>room)._patchInterval._idleTimeout > 0);
 

--- a/test/benchmark/RoomPatchBenchmark.ts
+++ b/test/benchmark/RoomPatchBenchmark.ts
@@ -1,0 +1,113 @@
+import * as Benchmark from "benchmark";
+import * as msgpack from "notepack.io";
+import * as fossilDelta from "fossil-delta";
+import * as nodeDelta from "node-delta";
+import * as util from "util";
+import { DummyRoom, createDummyClient } from "../utils/mock";
+import { generateId, Protocol } from "../../src";
+import { toJSON } from "../../src/Utils";
+
+const NUM_CLIENTS = 10;
+const NUM_MONSTERS = 500;
+const MAP_GRID_SIZE = 200;
+
+const suite = new Benchmark.Suite();
+const room = new DummyRoom();
+room.roomName = "dummy";
+room.roomId = generateId();
+
+// build 200x200 map
+const map = [];
+for (var i=0; i<MAP_GRID_SIZE; i++) {
+  map[i] = [];
+  for (var j=0; j<MAP_GRID_SIZE; j++) {
+    map[i].push( (Math.random() > 0.5) ? 0 : 1 );
+  }
+}
+
+// build 500 monsters
+let monsters = {};
+for (let i=0; i<NUM_MONSTERS; i++) {
+  monsters[ generateId() ] = {
+    x: Math.round(Math.random() * 200),
+    y: Math.round(Math.random() * 200)
+  };
+}
+
+// build 10 players
+let players = {};
+for (let i=0; i<NUM_CLIENTS; i++) {
+  let client = createDummyClient();
+  (<any>room)._onJoin( client );
+  players[ client.id ] = {
+    x: Math.round(Math.random() * 200),
+    y: Math.round(Math.random() * 200)
+  };
+}
+
+function moveMonsters () {
+  for (let id in monsters) {
+    monsters[ id ].x += (Math.random() > 0.5) ? 1 : -1;
+    monsters[ id ].y += (Math.random() > 0.5) ? 1 : -1;
+  }
+}
+
+function movePlayers () {
+  for (let id in players) {
+    players[ id ].x += (Math.random() > 0.5) ? 1 : -1;
+    players[ id ].y += (Math.random() > 0.5) ? 1 : -1;
+  }
+}
+
+let state = { map, monsters, players };
+
+let encodedState = msgpack.encode( state );
+let secondEncodedState = msgpack.encode( state );
+
+function distance (p1, p2) {
+  let a = p1.x - p2.x;
+  let b = p1.y - p2.y;
+  return Math.sqrt( a*a + b*b  );
+}
+
+room.setState(state);
+
+// suite.add('toJSON', () => toJSON(state));
+// suite.add('plain data', () => state);
+//
+// suite.add('encodedState.equals()', () => {
+//   encodedState.equals(secondEncodedState);
+// });
+
+let previousState = msgpack.encode(toJSON(state));
+moveMonsters();
+movePlayers();
+let nextState = msgpack.encode(toJSON(state));
+
+let deltaData = fossilDelta.create(previousState, nextState);
+
+// suite.add('fossilDelta.create()', () => {
+//   fossilDelta.create(previousState, nextState);
+// });
+//
+// suite.add('nodeDelta.create()', () => {
+//   nodeDelta.create(previousState, nextState);
+// });
+//
+// suite.add('msgpack.encode delta', () => {
+//   msgpack.encode([Protocol.ROOM_STATE_PATCH, room.roomId, deltaData]);
+// });
+
+let numBytesPatches = 0;
+suite.add('Room#broadcastPatch', function() {
+  moveMonsters();
+  movePlayers();
+  (<any>room).broadcastPatch();
+});
+
+suite.on('cycle', e => console.log( e.target.toString() ));
+
+suite.run();
+console.log("Done.")
+
+process.exit();

--- a/test/misc-benchmark/deepdiff.js
+++ b/test/misc-benchmark/deepdiff.js
@@ -1,0 +1,188 @@
+"use strict";
+
+console.log('benchmark: deep diff')
+
+var Benchmark = require('benchmark')
+  , fossilDelta = require('fossil-delta')
+  , msgpack = require('notepack.io')
+  , toJSON = require('../../lib/Utils').toJSON
+  , generateId = require('../../lib').generateId
+  , suite = new Benchmark.Suite()
+  // , deepEql = require('deep-eql')
+  , deepEqual = require('deep-equal');
+
+var obj1Equal = {
+  players: {
+    '1': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    '2': { x: 22, y: 10, radius: Math.PI, name: "Player Y" },
+    // '3': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '4': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '5': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '6': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '7': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '8': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '9': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '10': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '11': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '12': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '13': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '14': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '15': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '16': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '17': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '18': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '19': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '20': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '21': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '22': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '23': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '24': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '25': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+  },
+  messages: [ "One", "Two", "Three" ]
+}
+
+var obj2Equal = {
+  players: {
+    '1': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    '2': { x: 22, y: 10, radius: Math.PI, name: "Player Y" },
+    // '3': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '4': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '5': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '6': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '7': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '8': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '9': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '10': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '11': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '12': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '13': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '14': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '15': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '16': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '17': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '18': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '19': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '20': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '21': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '22': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '23': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '24': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '25': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+  },
+  messages: [ "One", "Two", "Three" ]
+}
+
+var obj1Differ = {
+  players: {
+    // '3': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '4': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '5': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '6': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '7': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '8': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '9': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '10': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '11': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '12': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '13': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '14': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '15': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '16': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '17': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '18': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '19': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '20': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '21': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '22': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '23': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '24': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '25': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    '1': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    '2': { x: 22, y: 10, radius: Math.PI, name: "Player Y" },
+  },
+  messages: [ "One", "Two", "Three" ]
+}
+
+var obj2Differ = {
+  players: {
+    // '3': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '4': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '5': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '6': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '7': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '8': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '9': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '10': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '11': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '12': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '13': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '14': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '15': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '16': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '17': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '18': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '19': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '20': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '21': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '22': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '23': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '24': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    // '25': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    '1': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    '2': { x: 22, y: 20, radius: Math.PI, name: "Player Y" },
+  },
+  messages: [ "One", "Two", "Three" ]
+}
+
+suite.add('compare EQUAL using deep-equal', function() {
+  if (!deepEqual(obj1Equal, JSON.parse(JSON.stringify(obj2Equal)))) {
+    throw new Error("oops");
+  }
+});
+
+suite.add('compare DIFFER using deep-equal', function() {
+  if (deepEqual(obj1Differ, JSON.parse(JSON.stringify(obj2Differ)))) {
+    throw new Error("oops");
+  }
+});
+
+var eq1 = toJSON(obj1Equal);
+var eq2 = toJSON(obj2Equal);
+suite.add('compare EQUAL before binary serialize', function() {
+  if (JSON.stringify(eq1) !== JSON.stringify(eq2)) {
+    throw new Error("oops");
+  }
+});
+
+var diff1 = toJSON(obj1Differ);
+var diff2 = toJSON(obj2Differ);
+suite.add('compare DIFFER before binary serialize', function() {
+  if (JSON.stringify(diff1) === JSON.stringify(diff2)) {
+    throw new Error("oops");
+  }
+});
+
+var eq11 = toJSON(obj1Equal);
+var eq22 = toJSON(obj2Equal);
+
+suite.add('compare EQUAL after binary serialize', function() {
+  if (!msgpack.encode(eq11).equals(msgpack.encode(eq22))) {
+    throw new Error("oops");
+  }
+});
+
+var diff11 = toJSON(obj1Differ);
+var diff22 = toJSON(obj2Differ);
+suite.add('compare DIFFER after binary serialize', function() {
+  if (msgpack.encode(diff11).equals(msgpack.encode(diff22))) {
+    throw new Error("oops");
+  }
+});
+
+
+suite.on('cycle', function(event) {
+  console.log(String(event.target));
+})
+
+suite.run()

--- a/test/misc-benchmark/patch.js
+++ b/test/misc-benchmark/patch.js
@@ -1,0 +1,151 @@
+"use strict";
+
+console.log('benchmark: evaluating a complex patch state')
+
+var Benchmark = require('benchmark')
+  , jsonpatch = require('fast-json-patch')
+  , fossilDelta = require('fossil-delta')
+  , msgpack = require('notepack.io')
+  , toJSON = require('../../lib/Utils').toJSON
+
+  , suite = new Benchmark.Suite()
+
+class PlainState {
+  constructor () {
+    this.integer = 1;
+    this.float = Math.PI
+    this.string = "Hello world"
+    this.array = [1,2,3,4,5,6,7,8,9,10]
+    this.objs = [{hp: 100, x: 0, y: 0}, {hp: 80, x: 10, y: 20}, {hp: 25, x: 8, y: -14}]
+    this.boolean = true
+    this.null = null
+    this.teams = [
+      { id: 0, score: 0 },
+      { id: 1, score: 0 },
+      { id: 2, score: 0 },
+      { id: 3, score: 0 }
+    ]
+  }
+}
+
+class ChildObject {
+  constructor (hp, x, y, parent) {
+    this.complexObject = global
+    this.parent = parent
+    this.hp = hp
+    this.x = x
+    this.y = y
+  }
+  toJSON () {
+    return { hp: this.hp, x: this.x, y: this.y }
+  }
+}
+
+class ComplexState {
+  constructor () {
+    this.complexObject = global
+    this.integer = 1;
+    this.float = Math.PI
+    this.string = "Hello world"
+    this.array = [1,2,3,4,5,6,7,8,9,10]
+    this.objs = [
+      new ChildObject(100, 0, 0, this),
+      new ChildObject(80, 10, 20, this),
+      new ChildObject(25, 8, -14, this)
+    ]
+    this.boolean = true
+    this.null = null
+    this.teams = [
+      { id: 0, score: 0 },
+      { id: 1, score: 0 },
+      { id: 2, score: 0 },
+      { id: 3, score: 0 }
+    ]
+  }
+  add(hp, x, y) {
+    this.objs.push( new ChildObject(hp, x, y, this) )
+  }
+  toJSON () {
+    return {
+      integer: this.integer,
+      float: this.float,
+      string: this.string,
+      array: this.array,
+      objs: this.objs,
+      boolean: this.boolean,
+      null: this.null,
+      teams: this.teams
+    }
+  }
+}
+
+var obj2 = new ComplexState();
+var state2 = JSON.parse(JSON.stringify(toJSON(obj2)))
+suite.add('using json', function() {
+  for (var i=0; i<4; i++) {
+    obj2.objs[0].hp--;
+    obj2.objs[2].hp--;
+    obj2.teams[i].score++;
+    var newState = JSON.parse(JSON.stringify(toJSON(obj2)))
+    var diff = msgpack.encode( jsonpatch.compare(state2, newState) )
+    state2 = newState
+  }
+})
+
+var obj3 = new PlainState();
+var observer = jsonpatch.observe(obj3)
+suite.add('using plain + observe', function() {
+  for (var i=0; i<4; i++) {
+    obj3.objs[0].hp--;
+    obj3.objs[2].hp--;
+    obj3.teams[i].score++;
+    var diff = msgpack.encode( jsonpatch.generate(observer) )
+  }
+})
+
+var obj4 = new ComplexState();
+var obj4state = JSON.parse(JSON.stringify(toJSON(obj4)))
+var observer2 = jsonpatch.observe(obj4state)
+suite.add('using complex + observe', function() {
+  for (var i=0; i<4; i++) {
+    obj4.objs[0].hp--;
+    obj4.objs[2].hp--;
+    obj4.teams[i].score++;
+    Object.assign(obj4state, toJSON(obj4))
+    var diff = msgpack.encode( jsonpatch.generate(observer2) )
+  }
+})
+
+var obj4 = new PlainState();
+var oldBinary4 = msgpack.encode( toJSON( obj4 ) )
+var newBinary4 = null
+suite.add('using plain + fossildelta', function() {
+  for (var i=0; i<4; i++) {
+    obj4.objs[0].hp--;
+    obj4.objs[2].hp--;
+    obj4.teams[i].score++;
+    newBinary4 = msgpack.encode( toJSON( obj4 ) )
+    var diff = fossilDelta.create( oldBinary4, newBinary4 )
+    oldBinary4 = newBinary4
+  }
+})
+
+var obj5 = new ComplexState();
+var oldBinary5 = msgpack.encode( toJSON( obj4 ) )
+var newBinary5 = null
+suite.add('using complex + fossildelta', function() {
+  for (var i=0; i<4; i++) {
+    obj5.objs[0].hp--;
+    obj5.objs[2].hp--;
+    obj5.teams[i].score++;
+    newBinary5 = msgpack.encode( toJSON( obj5 ) )
+    var diff = fossilDelta.create( oldBinary5, newBinary5 )
+    oldBinary5 = newBinary5
+  }
+})
+
+suite.on('cycle', function(event) {
+  console.log(String(event.target));
+})
+
+suite.run()

--- a/test/misc-benchmark/size.js
+++ b/test/misc-benchmark/size.js
@@ -1,0 +1,41 @@
+"use strict";
+
+console.log('benchmark: evaluating a complex patch state')
+
+var Benchmark = require('benchmark')
+  , fossilDelta = require('fossil-delta')
+  , nodeDelta = require('node-delta')
+  , msgpack = require('notepack.io')
+  , toJSON = require('../../lib/Utils').toJSON
+  , generateId = require('../../lib').generateId
+  , suite = new Benchmark.Suite()
+
+var deepObject = { entities: {} };
+var wave = 1;
+var numPlayers = 2;
+
+for (var i = 0, len = 100; i < len; i++) {
+  deepObject.entities[ generateId() ] = { x: Math.random(), y: Math.random() };
+}
+
+var deepObject2 = {entities: {}};
+for (var id in deepObject.entities) {
+  deepObject2.entities[id] = { x: Math.random(), y: Math.random() };
+}
+
+console.log(deepObject)
+console.log(deepObject2)
+
+suite.add('fossil-delta', function() {
+  fossilDelta.create(msgpack.encode(deepObject), msgpack.encode(deepObject2))
+});
+
+suite.add('node-delta', function() {
+  nodeDelta.create(msgpack.encode(deepObject), msgpack.encode(deepObject2))
+});
+
+suite.on('cycle', function(event) {
+  console.log(String(event.target));
+});
+
+suite.run();

--- a/test/misc-benchmark/toJSON.js
+++ b/test/misc-benchmark/toJSON.js
@@ -1,0 +1,30 @@
+"use strict";
+
+console.log('benchmark: toJSON');
+
+var Benchmark = require('benchmark')
+  , toJSON = require('../../lib/Utils').toJSON
+  , suite = new Benchmark.Suite()
+
+var obj = {
+  players: {
+    '1': { x: 44.4444, y: 55.5555, radius: 0.12312313, name: "Player X" },
+    '2': { x: 22, y: 10, radius: Math.PI, name: "Player Y" },
+  },
+  messages: [ "One", "Two", "Three" ]
+}
+
+suite.add('toJSON', function() {
+  toJSON(obj);
+});
+
+suite.add('JSON.stringify', function() {
+  JSON.stringify(obj);
+});
+
+
+suite.on('cycle', function(event) {
+  console.log(String(event.target));
+})
+
+suite.run()

--- a/test/utils/mock.ts
+++ b/test/utils/mock.ts
@@ -3,6 +3,7 @@ import * as shortid from "shortid";
 import * as msgpack from "notepack.io";
 import * as WebSocket from "ws";
 import { Room } from "../../src/Room";
+import { LocalPresence } from './../../src/presence/LocalPresence';
 
 export class Client extends EventEmitter {
 
@@ -44,6 +45,10 @@ export function createDummyClient (options?: any): any {
 }
 
 export class DummyRoom extends Room {
+  constructor () {
+    super(new LocalPresence());
+  }
+
   requestJoin (options) {
     return !options.invalid_param
   }
@@ -56,6 +61,9 @@ export class DummyRoom extends Room {
 }
 
 export class RoomWithError extends Room {
+  constructor () {
+    super(new LocalPresence());
+  }
   onInit () { this.setState({}); }
   onDispose() {}
   onJoin() {
@@ -68,7 +76,7 @@ export class RoomWithError extends Room {
 
 export class DummyRoomWithState extends Room {
   constructor () {
-    super();
+    super(new LocalPresence());
     this.setState({ number: 10 });
   }
 
@@ -85,10 +93,9 @@ export class DummyRoomWithState extends Room {
 
 export class DummyRoomWithTimeline extends Room {
   constructor () {
-    super();
+    super(new LocalPresence());
     this.useTimeline()
   }
-
 
   requestJoin (options) {
     return !options.invalid_param


### PR DESCRIPTION
(Implements #147)

I've set a poll to gather what you guys think about this feature being enabled by default or not. What do you think?

[![](https://api.gh-polls.com/poll/01CDFXAWAZTHJB7223G5NVM4CN/enabled%20by%20default)](https://api.gh-polls.com/poll/01CDFXAWAZTHJB7223G5NVM4CN/enabled%20by%20default/vote)
[![](https://api.gh-polls.com/poll/01CDFXAWAZTHJB7223G5NVM4CN/disabled%20by%20default)](https://api.gh-polls.com/poll/01CDFXAWAZTHJB7223G5NVM4CN/disabled%20by%20default/vote)

Things to consider when reconnection is enabled:
- The rooms will live for a bit longer (15 seconds by default), even if there're no more clients connected to it and `autoDispose` is set to `true`.
- Reconnecting clients will skip `requestJoin` method, since it was authorized already before.

**Usage**

```typescript
class MyRoom extends Room {
  onJoin (client) {
    this.state.setupClient(client.sessionId);
  }

  async onLeave (client) {
    this.state.inactivateClient(client.sessionId);

    try {
      // allow client to reconnect within 20 seconds
      const reconnectedClient = await this.allowReconnection(client, 20); 

      // client reconnected!
      this.state.reactivateClient(client.sessionId);

    } catch (e) {
      // client couldn't reconnect within 20 seconds
      this.state.removeClient(client.sessionId);
    }
  }
}
```