### PR TITLE
Add server option shutdownProcessOnSignal

### DIFF
--- a/src/Server.ts
+++ b/src/Server.ts
@@ -24,6 +24,7 @@ export type ServerOptions = IServerOptions & {
   presence?: any,
   engine?: any,
   ws?: any,
+  shutdownProcessOnSignal?: Boolean,
 };
 
 export class Server {
@@ -48,12 +49,16 @@ export class Server {
     // "presence" option is not used from now on
     delete options.presence;
 
-    registerGracefulShutdown((signal) => {
-      this.matchMaker.gracefullyShutdown().
-        then(() => this.shutdown()).
-        catch((err) => debugError(`error during shutdown: ${err}`)).
-        then(() => process.exit());
-    });
+    if(options.shutdownProcessOnSignal !== false) {
+      registerGracefulShutdown((signal) => {
+        this.matchMaker.gracefullyShutdown().
+          then(() => this.shutdown()).
+          catch((err) => debugError(`error during shutdown: ${err}`)).
+          then(() => {
+            process.exit()
+          });
+      });
+    }
 
     if (options.server) {
       this.attach(options);

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -24,7 +24,7 @@ export type ServerOptions = IServerOptions & {
   presence?: any,
   engine?: any,
   ws?: any,
-  shutdownProcessOnSignal?: Boolean,
+  shutdownProcessOnSignal?: boolean,
 };
 
 export class Server {
@@ -50,13 +50,13 @@ export class Server {
     delete options.presence;
 
     const { shutdownProcessOnSignal = true } = options;
-    if(shutdownProcessOnSignal) {
+    if (shutdownProcessOnSignal) {
       registerGracefulShutdown((signal) => {
         this.matchMaker.gracefullyShutdown().
           then(() => this.shutdown()).
           catch((err) => debugError(`error during shutdown: ${err}`)).
           then(() => {
-            process.exit()
+            process.exit();
           });
       });
     }

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -49,7 +49,8 @@ export class Server {
     // "presence" option is not used from now on
     delete options.presence;
 
-    if(options.shutdownProcessOnSignal !== false) {
+    const { shutdownProcessOnSignal = true } = options;
+    if(shutdownProcessOnSignal) {
       registerGracefulShutdown((signal) => {
         this.matchMaker.gracefullyShutdown().
           then(() => this.shutdown()).


### PR DESCRIPTION
This option changes nothing by default, but if it is set to `false` it disables the automatic process shutdown when a kill signal is received.

See #188 for reasoning.