### PR TITLE
Fix async onDispose during graceful shutdown

### DIFF
--- a/src/Room.ts
+++ b/src/Room.ts
@@ -84,7 +84,10 @@ export abstract class Room<T= any> extends EventEmitter {
 
     this.presence = presence;
 
-    this.once('dispose', () => this._dispose());
+    this.once('dispose', async () => {
+      await this._dispose();
+      this.emit('disposeComplete');
+    });
 
     this.setPatchRate(this.patchRate);
   }
@@ -245,7 +248,7 @@ export abstract class Room<T= any> extends EventEmitter {
     }
 
     return new Promise((resolve, reject) => {
-      this.once('dispose', () => resolve());
+      this.once('disposeComplete', () => resolve());
     });
   }
 


### PR DESCRIPTION
## Problem

There is a bug during graceful shutdown. If onDispose returns a promise it won't wait for it to resolve before the process terminates. This bug doesn't happen when a room is being automatically disposed if clients have left and autoDispose property is set to true.

## Steps to reproduce

In a room handler, setup the onDispose method to something like this:
```
onDispose() {
  return new Promise((resolve, reject) => {
    console.log("onDispose: Timeout started");
    setTimeout(() => {
      console.log("onDispose: Timeout complete");
      resolve();
    }, 2000);
  });
}
```
Then connect clients to a room and terminate the running process (CTRL+C on the terminal)
You should see the first message `onDispose: Timeout started` printed but not the second.

## Cause

In Room.ts the constructor sets up a listener for "dispose" to handle proper disposing of the room (and eventually running `this.onDispose` if set). During graceful shutdown, the `disconnect()` method also registers another listener for "dispose" which simply resolves it without waiting for the other listener to complete any async calls.

## Solution

My proposed solution is to emit a "disposeComplete" event when the main "dispose" listener (in  Room.ts constructor) completes, and have the disconnect method register a listener for "disposeComplete" instead.
